### PR TITLE
Removed CSS and SparQL formats.

### DIFF
--- a/draft-pot-prefer-push.md
+++ b/draft-pot-prefer-push.md
@@ -171,48 +171,6 @@ GET /articles HTTP/1.1
 Prefer: push="(item(author \"https://example.org/custom-rel\") icon)"
 ~~~~
 
-## N-depth pushes with CSS syntax
-
-A different suggestion was made using a combination of a subset of CSS3
-selector syntax {{W3C.REC-selectors-3-20181106}} combined with the CSS
-syntax of specifing urls.
-
-### Example using Prefer-Push header
-
-~~~~
-GET /articles HTTP/1.1
-Prefer-Push: item, item > author, item >
-  url("https://example.org/custom-rel"), icon
-~~~~
-
-### Example using Prefer header
-
-~~~~
-GET /articles HTTP/1.1
-Prefer: push="item, item > author, item >
-  url(\"https://example.org/custom-rel\"), icon"
-~~~~
-
-## N-depth pushes with SparQL property paths
-
-The following format is inspired by SparQL property paths.
-
-### Example using Prefer-Push header
-
-~~~~
-GET /articles HTTP/1.1
-Prefer-Push: item / ( author, <https://example.org/custom-rel> ),
-  icon
-~~~~
-
-### Example using Prefer header
-
-~~~~
-GET /articles HTTP/1.1
-Prefer: push="item / ( author, <https://example.org/custom-rel> ),
-  icon"
-~~~~
-
 # Server pushes
 
 When a server receives the `Prefer(-Push)` header, it can choose to push the


### PR DESCRIPTION
The motivation for using a CSS or SparQL syntax was re-use an existing
well-known format, over defining a new one.

However, neither of these proposals are actually valid subsets of the
syntax they hope to use, which I think makes this argument largely moot

Updates #4 